### PR TITLE
Fix: 循环获取玩家坐标插件 未移除下线玩家的坐标数据, 导致世界的记忆一直在尝试重发获取 unloaded 区块的数据包.

### DIFF
--- a/前置_主动区块请求/__init__.py
+++ b/前置_主动区块请求/__init__.py
@@ -109,7 +109,7 @@ class AutoSubChunkRequest(Plugin):
         self.ListenBytesPacket(PacketIDS.SubChunk, self.on_sub_chunk)
 
     def on_def(self):
-        _ = self.GetPluginAPI("循环获取玩家坐标", (0, 0, 3))
+        _ = self.GetPluginAPI("循环获取玩家坐标", (0, 0, 4))
 
     def on_inject(self):
         self.blob_hash = self.game_ctrl.blob_hash_holder()

--- a/前置_主动区块请求/datas.json
+++ b/前置_主动区块请求/datas.json
@@ -4,7 +4,7 @@
   "plugin-type": "classic",
   "description": "自动请求区块数据，并将二进制化的数据分发给任何需要的插件",
   "pre-plugins": {
-    "循环获取玩家坐标": "0.0.3"
+    "循环获取玩家坐标": "0.0.4"
   },
   "plugin-id": "主动区块请求",
   "enabled": true

--- a/前置_循环获取玩家坐标/__init__.py
+++ b/前置_循环获取玩家坐标/__init__.py
@@ -16,7 +16,6 @@ class GlobalGetPlayerPos(Plugin):
         self.ListenInternalBroadcast("ggpp:set_crycle", self.set_cycle)
 
     def on_inject(self):
-        self.player_posdata: dict[str, dict] = {}
         self._main_thread()
 
     def set_cycle(self, event: InternalBroadcast):
@@ -48,7 +47,7 @@ class GlobalGetPlayerPos(Plugin):
         """
         self.get_and_publish_player_position()
 
-    def publish_position(self):
+    def publish_position(self, play_pos_data: dict):
         """
         API (ggpp:publish_player_position): 发布玩家坐标信息
 
@@ -74,7 +73,7 @@ class GlobalGetPlayerPos(Plugin):
             ```
         """
         self.BroadcastEvent(
-            InternalBroadcast("ggpp:publish_player_position", self.player_posdata)
+            InternalBroadcast("ggpp:publish_player_position", play_pos_data)
         )
 
     def get_and_publish_player_position(self):
@@ -101,8 +100,7 @@ class GlobalGetPlayerPos(Plugin):
                 "yRot": i["yRot"],
                 "dimension": int(i["dimension"]),
             }
-        self.player_posdata = player_posdata
-        self.publish_position()
+        self.publish_position(player_posdata)
 
     @utils.thread_func("循环获取玩家坐标")
     def _main_thread(self):

--- a/前置_循环获取玩家坐标/__init__.py
+++ b/前置_循环获取玩家坐标/__init__.py
@@ -6,7 +6,7 @@ from tooldelta import InternalBroadcast, Plugin, fmts, utils, plugin_entry
 class GlobalGetPlayerPos(Plugin):
     name = "前置-循环获取玩家坐标"
     author = "ToolDelta"
-    version = (0, 0, 3)
+    version = (0, 0, 4)
     CYCLE = 1
 
     def __init__(self, frame):
@@ -79,6 +79,7 @@ class GlobalGetPlayerPos(Plugin):
 
     def get_and_publish_player_position(self):
         uuid2player = {v: k for k, v in self.game_ctrl.players_uuid.items()}
+        player_posdata = {}
 
         try:
             result = self.game_ctrl.sendcmd_with_resp("/querytarget @a")
@@ -93,13 +94,14 @@ class GlobalGetPlayerPos(Plugin):
         content = json.loads(result.OutputMessages[0].Parameters[0])
         for i in content:
             player_name = uuid2player[i["uniqueId"]]
-            self.player_posdata[player_name] = {
+            player_posdata[player_name] = {
                 "x": i["position"]["x"],
                 "y": i["position"]["y"],
                 "z": i["position"]["z"],
                 "yRot": i["yRot"],
                 "dimension": int(i["dimension"]),
             }
+        self.player_posdata = player_posdata
         self.publish_position()
 
     @utils.thread_func("循环获取玩家坐标")

--- a/前置_循环获取玩家坐标/datas.json
+++ b/前置_循环获取玩家坐标/datas.json
@@ -1,6 +1,6 @@
 {
     "author": "ToolDelta",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "前置插件, 通过此插件的 1s 更新一次(可更改)玩家坐标可获取全服玩家的坐标",
     "plugin-type": "classic",
     "pre-plugins": {},


### PR DESCRIPTION
![IMG_20250504_140550](https://github.com/user-attachments/assets/4ae61c8b-0a06-4552-a0a4-f2ca8df8a902)
