### PR TITLE
添加远程音乐库点歌功能，修复Player.name输出错误

### DIFF
--- a/点歌台/GetFile.py
+++ b/点歌台/GetFile.py
@@ -1,0 +1,54 @@
+import os
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+
+def fetch_github_api(api_url):
+    try:
+        response = requests.get(api_url, verify=False)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            print(f"Failed to fetch files. Status code: {response.status_code}")
+            return None
+    except Exception as e:
+        print(f"An error occurred while fetching files: {e}")
+        return None
+
+def get_github_repo_files(repo_url):
+    api_url = f"https://api.github.com/repos/{repo_url}/contents"
+    files = fetch_github_api(api_url)
+    message = fetch_message_content(repo_url)
+    if files:
+        file_names = []
+        for file in files:
+            if file.get('type') == 'file':
+                name = file['name']
+                main_name, ext = os.path.splitext(name)
+                if main_name.lower() == 'message': 
+                #SM的玩意，message.json就是过滤不掉，还是改下点歌台那里吧...
+                    continue
+                if ext.lower() in ('.mid', '.midi'):
+                    file_names.append(main_name)
+        return file_names, message
+    else:
+        return [], message
+
+def fetch_message_content(repo_url):
+    """
+    获取 Message.json 文件的内容并返回
+    """
+    try:
+        headers = {
+            'User-Agent': 'Mozilla/5.0'
+        }
+        #经过测试，ghproxy.net 似乎是唯一一个能直接下载的,而官方提供的github.tooldelta.top却选择了拒绝连接
+        message_url = f"https://ghproxy.net/https://raw.githubusercontent.com/{repo_url}/main/Message.json"
+        message_response = requests.get(message_url, headers=headers, verify=False)
+        if message_response.status_code == 200:
+            return message_response.json().get('message')
+        return None
+    except Exception as e:
+        print(f"Error fetching message: {e}")
+        return None

--- a/点歌台/__init__.py
+++ b/点歌台/__init__.py
@@ -1,5 +1,6 @@
 import os
 from typing import TYPE_CHECKING, ClassVar
+from GetFile import get_github_repo_files 
 from tooldelta import utils, Plugin, Player, plugin_entry
 
 
@@ -16,6 +17,8 @@ class DJTable(Plugin):
         super().__init__(frame)
         os.makedirs(self.data_path, exist_ok=True)
         os.makedirs(os.path.join(self.data_path, "音乐列表"), exist_ok=True)
+        self.mdir_external = os.path.join(self.data_path, "远程缓存")
+        os.makedirs(self.mdir_external, exist_ok=True)
         self.ListenPreload(self.on_def)
         self.ListenActive(self.on_inject)
         self.ListenPlayerJoin(self.on_player_join)
@@ -45,17 +48,28 @@ class DJTable(Plugin):
                 )
                 midi_names.append(i.replace(".midseq", ""))
         self.midis_list = midi_names
+        self.repo_url = "Zhonger-Yuansi/Midi-Repositories"
+        try:
+            repo_url = self.repo_url
+            # 获取文件列表和公告消息
+            remote_data = get_github_repo_files(repo_url)
+            original_list, self.repo_message = remote_data
+            self.remote_midis_list = [name for name in original_list if name.lower() != 'message']
+        except Exception as e:
+            self.logger.error(f"获取远程音乐列表失败: {e}")
+            self.remote_midis_list = []
+            self.repo_message = None
 
     def on_inject(self):
-        self.game_ctrl.sendcmd("/scoreboard objectives add song_point dummy 音乐点")
-        self.game_ctrl.sendcmd("/scoreboard players add @a song_point 0")
+        self.game_ctrl.sendwocmd("/scoreboard objectives add song_point dummy 音乐点")
+        self.game_ctrl.sendwocmd("/scoreboard players add @a song_point 0")
         self.chatmenu.add_new_trigger(
             ["点歌列表"], [], "查看点歌台点歌列表", self.lookup_songs_list
         )
         self.chatmenu.add_new_trigger(["点歌"], [("歌名", str, "")], "点歌", self.choose_menu)
         self.chatmenu.add_new_trigger(
             ["停止当前曲目"],
-            [],
+            None,
             "停止当前点歌曲目",
             self.force_stop_current,
             op_only=True,
@@ -76,13 +90,30 @@ class DJTable(Plugin):
             player.show("§a当前曲目列表：")
             for i, j in enumerate(song_list):
                 player.show(f" §b{i + 1} §f{j}")
+            if hasattr(self, 'remote_midis_list') and self.remote_midis_list:
+                player.show("§a远程音乐库曲目：")
+                for i, name in enumerate(self.remote_midis_list):
+                    player.show(f" §b{len(song_list) + i + 1} §f{name} §7(远程)")
+                if hasattr(self, 'repo_message'):
+                    if self.repo_message:
+                        player.show(f"§7远程仓库: {self.repo_message}")
+                    else:
+                        player.show("§7远程仓库: 当前暂无公告内容")
             if (resp := utils.try_int(player.input("§a请输入序号选择曲目："))) is None:
                 player.show("§c选项无效")
                 return
-            elif resp not in range(1, len(song_list) + 1):
+            total_options = len(song_list) + len(self.remote_midis_list)
+            if resp < 1 or resp > total_options:
                 player.show("§c选项不在范围内")
                 return
-            music_name = song_list[resp - 1].removesuffix(".midseq")
+            if resp <= len(song_list):
+                music_name = song_list[resp - 1].removesuffix(".midseq")
+            else:
+                remote_index = resp - len(song_list) - 1
+                music_name = self.remote_midis_list[remote_index]
+                player.show("§e点歌§f>> §7正在下载并处理远程曲目，请稍候...")
+                self._download_process(player, music_name)
+                return
         else:
             for song_name in song_list:
                 if song_name.removesuffix(".midseq") == choose_song_name:
@@ -96,12 +127,12 @@ class DJTable(Plugin):
         elif player.getScore("song_point") <= 0:
             player.show("§e点歌§f>> §c音乐点数不足，点歌一次需消耗§e1§c点")
         else:
-            self.musics_list.append((music_name, player))
+            self.musics_list.append((music_name, player.name))
             player.show("§e点歌§f>> §a点歌成功， 消耗1点音乐点")
             self.game_ctrl.sendwocmd(
-                f"/scoreboard players remove {player} song_point 1"
+                f"/scoreboard players remove {player.name} song_point 1"
             )
-            self.game_ctrl.say_to("@a", f"§e点歌§f>> §e{player}§a成功点歌:{music_name}")
+            self.game_ctrl.say_to("@a", f"§e点歌§f>> §e{player.name}§a成功点歌:{music_name}")
 
     def lookup_songs_list(self, player: Player, _):
         if not self.musics_list == []:
@@ -111,7 +142,10 @@ class DJTable(Plugin):
         else:
             player.show("§a♬§f列表空空如也啦! ")
 
-    def force_stop_current(self, player: Player, _):
+
+
+
+    def force_stop_current(self, player, _):
         if self.can_stop:
             self.main_thread.stop()
             self.game_ctrl.say_to("@a", "§e点歌§f>> §6管理员已停止当前点歌曲目")
@@ -121,7 +155,7 @@ class DJTable(Plugin):
     def play_music(self, song_name, player):
         self.game_ctrl.say_to(
             "@a",
-            f"§e点歌§f>> §7开始播放§f{song_name}§7，点歌者:§f{player}",
+            f"§e点歌§f>> §7开始播放§f{song_name}§7，点歌者:§f{player.name}",
         )
         try:
             self.midiplayer.playsound_at_target_sync(song_name, "@a")
@@ -140,5 +174,48 @@ class DJTable(Plugin):
                 self.play_music, args=(song_name, player)
             )
 
+    def _download_process(self, player: Player, music_name: str, **kwargs):
+        """下载远程音乐并完成转换及播放入队"""
+        try:
+            import requests
+            from urllib3.exceptions import InsecureRequestWarning
+            requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+            
+            """
+            
+            清空外部缓存文件夹
+            可能这会给面板带来一点流量占用
+            但是MIDI仓库的主人不一定获取到MIDI作者的授权
+            所以这一步至关重要
+
+            """
+            for file in os.listdir(self.mdir_external):
+                try:
+                    os.remove(os.path.join(self.mdir_external, file))
+                except Exception as e:
+                    self.logger.error(f"清空缓存失败: {e}")
+            
+
+            url = f"https://ghproxy.net/https://raw.githubusercontent.com/{self.repo_url}/main/{music_name}.mid"
+            response = requests.get(url)
+
+
+            if response.status_code == 200:
+                midi_path = os.path.join(self.mdir_external, f"{music_name}.mid")
+                with open(midi_path, "wb") as file:
+                    file.write(response.content)
+            
+            midseq_path = os.path.join(self.mdir_external, f"{music_name}.midseq")
+            self.midiplayer.translate_midi_to_seq_file(midi_path, midseq_path)
+            os.remove(midi_path) 
+            
+
+            self.midiplayer.load_sound_seq_file(midseq_path, music_name)
+            self.musics_list.append((music_name, player))
+            player.show("§e点歌§f>> §a远程曲目已加入播放队列！")
+        
+        except Exception as e:
+            self.logger.error(f"处理远程音乐异常: {e}")
+            player.show(f"§c处理远程曲目失败: {str(e)}")
 
 entry = plugin_entry(DJTable)

--- a/点歌台/datas.json
+++ b/点歌台/datas.json
@@ -1,7 +1,7 @@
 {
-  "author": "SuperScript",
-  "version": "0.1.7",
-  "description": "想在在服内点歌？ 使用这个点歌台插件吧！\n歌曲MIDI文件需要放置于 §6插件数据文件/点歌台/音乐列表§f 下\n在服内输入 help 可查看点歌指令\n消耗的音乐点于计分板 song_point, 可自行添加分数",
+  "author": "SuperScript & Zhonger-Yuansi",
+  "version": "0.2.0",
+  "description": "想在在服内点歌？ 使用这个点歌台插件吧！\n歌曲MIDI文件需要放置于 §6插件数据文件/点歌台/音乐列表§f 下或者使用远程音乐仓库\n在服内输入 help 可查看点歌指令\n消耗的音乐点于计分板 song_point, 可自行添加分数",
   "limit_launcher": null,
   "pre-plugins": {
     "聊天栏菜单": "0.1.13",


### PR DESCRIPTION
允许从GITHUB仓库下载MIDI并播放，同时修复了原来直接输出Player的错误输出，修改为player.name